### PR TITLE
Option to set ctermbg for Normal to none

### DIFF
--- a/colors/zenburn.vim
+++ b/colors/zenburn.vim
@@ -136,6 +136,10 @@
 "   or 
 "      let g:zenburn_alternate_Include = 0
 "
+" * To remove the backgroind color or to use with terminal 
+"   with transparent background, use
+"
+"      let g:zenburn_terminal_Background = 1
 "
 " That's it, enjoy!
 "


### PR DESCRIPTION
If it's used with a terminal with zenburn colors and/or transparent
background vim's background is in the way.

Signed-off-by: Vesselin Petkov mail@vpetkov.com
