### PR TITLE
Config option for transparent terminals

### DIFF
--- a/README
+++ b/README
@@ -1,9 +1,5 @@
 ZENBURN
 
-This is a fork of Zenburn with a solid black background for transparent terminals.
-
-
-
 Zenburn is a low-contrast color scheme for Vim. It’s easy for your eyes and
 designed to keep you in the zone for long programming sessions.
 


### PR DESCRIPTION
Sets the background color in cterm and gui to 0 and #000000 when g:zenburn_transparent is 1.
