### PR TITLE
obey zenburn_italic_Comment in gui mode

### DIFF
--- a/colors/zenburn.vim
+++ b/colors/zenburn.vim
@@ -228,9 +228,9 @@ hi Character       guifg=#dca3a3 gui=bold                     ctermfg=181 cterm=
 if exists("g:zenburn_italic_Comment") && g:zenburn_italic_Comment
     hi Comment         guifg=#7f9f7f gui=italic                   ctermfg=108 cterm=italic
 else
-    hi Comment         guifg=#7f9f7f gui=italic                   ctermfg=108
+    hi Comment         guifg=#7f9f7f                              ctermfg=108
 endif
-hi Comment         guifg=#7f9f7f gui=italic                   ctermfg=108
+hi Comment         guifg=#7f9f7f                              ctermfg=108
 hi Conditional     guifg=#f0dfaf gui=bold                     ctermfg=223 cterm=bold
 hi Constant        guifg=#dca3a3 gui=bold                     ctermfg=181 cterm=bold
 hi Cursor          guifg=#000d18 guibg=#8faf9f gui=bold       ctermfg=233 ctermbg=109 cterm=bold


### PR DESCRIPTION
Hi, happy zenburn user of >10 years here!  I was just trying to remove italicized comments (cool feature, but Terminus doesn't look good italicized).

As far as I can tell, `g:zenburn_italic_Comment` is currently only obeyed in terminal mode.  This changes the behavior so that italics in gui mode (nvim, gvim, vimx) is controlled by `g:zenburn_italic_Comment` as well.

I realize this change would remove italics from users who are using zenburn in nvim/gvim/vimx, but haven't set `g:zenburn_italic_Comment = 1` because they didn't have to.