### PR TITLE
add g:zenburn_disable_bold_CursorLine

### DIFF
--- a/colors/zenburn.vim
+++ b/colors/zenburn.vim
@@ -111,6 +111,12 @@
 "   ":set cursorline cursorcolumn", since otherwise the effect won't be
 "   seen.
 "
+" * With g:zenburn_high_Contrast enabled, the CursorLine and CursorColumn will
+"   be bold.  If you don't like it, bold CursorLine and CursorColumn can be
+"   disabled with:
+"
+"      let g:zenburn_disable_bold_CursorBars=1
+"
 " * New (dark) Visual coloring has been introduced.
 "   The dark Visual is more aligned with the rest of the colour scheme,
 "   especially if you use line numbers. If you wish to use the 
@@ -199,6 +205,10 @@ endif
 
 if ! exists("g:zenburn_unified_CursorColumn")
     let g:zenburn_unified_CursorColumn = 0
+endif
+
+if ! exists("g:zenburn_disable_bold_CursorBars")
+    let g:zenburn_disable_bold_CursorBars = 0
 endif
 
 if ! exists("g:zenburn_old_Visual")
@@ -296,13 +306,26 @@ if exists("g:zenburn_high_Contrast") && g:zenburn_high_Contrast
     hi Normal        guifg=#dcdccc guibg=#1f1f1f           ctermfg=188 ctermbg=234
     hi Conceal       guifg=#8f8f8f guibg=#333333           ctermfg=246 ctermbg=235
     hi ColorColumn   guibg=#33332f                         ctermbg=235
-    hi CursorLine    guibg=#121212 gui=bold                ctermbg=233 cterm=none
-    hi CursorLineNr  guifg=#f2f3bb guibg=#161616           ctermfg=229 ctermbg=233
-    if exists("g:zenburn_unified_CursorColumn") && g:zenburn_unified_CursorColumn
-        hi CursorColumn  guibg=#121212 gui=bold            ctermbg=233 cterm=none
+    if exists("g:zenburn_disable_bold_CursorBars") && g:zenburn_disable_bold_CursorBars
+        " no bold
+        if exists("g:zenburn_unified_CursorColumn") && g:zenburn_unified_CursorColumn
+            hi CursorColumn  guibg=#121212                     ctermbg=233 cterm=none
+        else
+            hi CursorColumn  guibg=#2b2b2b                     ctermbg=235 cterm=none
+        endif
+
+        hi CursorLine    guibg=#121212                         ctermbg=233 cterm=none
     else
-        hi CursorColumn  guibg=#2b2b2b                     ctermbg=235 cterm=none
+        " bold!
+        if exists("g:zenburn_unified_CursorColumn") && g:zenburn_unified_CursorColumn
+            hi CursorColumn  guibg=#121212 gui=bold            ctermbg=233 cterm=bold
+        else
+            hi CursorColumn  guibg=#2b2b2b gui=bold            ctermbg=235 cterm=bold
+        endif
+
+        hi CursorLine    guibg=#121212 gui=bold                ctermbg=233 cterm=bold
     endif
+    hi CursorLineNr  guifg=#f2f3bb guibg=#161616           ctermfg=229 ctermbg=233
     hi FoldColumn    guibg=#161616                         ctermbg=233 ctermfg=109
     hi Folded        guibg=#161616                         ctermbg=233 ctermfg=109
     hi LineNr        guifg=#9fafaf guibg=#161616           ctermfg=248 ctermbg=233


### PR DESCRIPTION
This PR adds a new configuration, `g:zenburn_disable_bold_CursorLine`.  

I named it `zenburn_disable_bold_CursorLine` instead of `zenburn_bold_CursorLine` to preserve zenburn's convention of config defaults always being `0`.

Let me know what you think.  Thanks!